### PR TITLE
benchmark: use plain text proxy.

### DIFF
--- a/cmd/test-utils.go
+++ b/cmd/test-utils.go
@@ -86,3 +86,40 @@ func assertHttpRequestOK(tb testing.TB, resp *http.Response) {
 		tb.Errorf("Should have gotten succesful request")
 	}
 }
+
+func fixture_with_environment_values(tb testing.TB, new_env map[string]string) (tearDown func ()()){
+	old_env_variables := map[string]string{}
+
+	for new_env_key, new_env_value := range new_env {
+		old_value, old_value_exists := os.LookupEnv(new_env_key)
+		if old_value_exists {
+			old_env_variables[new_env_key] = old_value
+		}
+		err := os.Setenv(new_env_key, new_env_value)
+		if err != nil {
+			tb.Errorf("Issue environment fixture when setting %s=%s got %s", new_env_key, new_env_value, err)
+			tb.FailNow()
+		}
+	}
+
+	tearDown = func() () {
+		for new_env_key, new_env_value := range new_env {
+			old_value, old_value_exists := os.LookupEnv(new_env_key)
+			if old_value_exists {
+				err := os.Setenv(new_env_key, old_value)
+				if err != nil {
+					tb.Errorf("Issue environment fixture when setting %s=%s got %s", new_env_key, new_env_value, err)
+					tb.FailNow()
+				}
+			} else {
+				err := os.Unsetenv(new_env_key)
+				if err != nil {
+					tb.Errorf("Issue environment fixture when unsetting %s=%s got %s", new_env_key, new_env_value, err)
+					tb.FailNow()
+				}
+			}
+			
+		}
+	}
+	return tearDown
+}


### PR DESCRIPTION
In order to not have misleading benchmark outcomes as detailed in https://github.com/VITObelgium/fakes3pp/pull/21#issuecomment-2620902233 we will benchmark with a plaintext proxy from now on. This will make the process slower but the results will be more intuitive.